### PR TITLE
Fix to allow compilation on OS X 10.5+

### DIFF
--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -45,8 +45,14 @@ extern int vsnprintf(char *str, size_t size, const char *format, va_list ap);
 #endif
 
 #ifdef __APPLE__
+#ifndef __clang__
 #define LOGOG_USE_TR1 1
-#endif
+#else
+#if !(__has_include(<unordered_map>))
+#define LOGOG_USE_TR1 1
+#endif // !(__has_include(<unordered_map>))
+#endif // __clang
+#endif // __APPLE__
 
 /* Detect IBM's XL C++ */
 #ifdef __IBMCPP__


### PR DESCRIPTION
...ed_map instead of the TR1 version.
