### PR TITLE
Improvements to LogFile

### DIFF
--- a/include/target.hpp
+++ b/include/target.hpp
@@ -90,8 +90,11 @@ public:
      * \param sFileName The name of the file to be created.
      * Since file names do not support Unicode on most systems, there is no option to create 
      * a filename with a LOGOG_CHAR. 
+     * \param bEnableOutputBuffering Whether to perform output buffering, or
+     * flush after each write.
      */
-    LogFile(const char *sFileName);
+    LogFile(const char *sFileName,
+            bool bEnableOutputBuffering = true);
 
     /** Closes the log file. */
     virtual ~LogFile();
@@ -119,6 +122,7 @@ protected:
     bool m_bFirstTime;
 	bool m_bOpenFailed;
     FILE *m_pFile;
+    bool m_bEnableOutputBuffering;
 
 	/** Does the actual fwrite to the file.  Call Output() instead to handle error conditions better. */
 	virtual int InternalOutput( size_t nSize, const LOGOG_CHAR *pData );

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -78,10 +78,11 @@ namespace logog {
 		return 0;
 	}
 
-	LogFile::LogFile(const char *sFileName) :
+	LogFile::LogFile(const char *sFileName, bool bEnableOutputBuffering) :
 		m_bFirstTime( true ),
 		m_bOpenFailed( false ),
-		m_pFile( NULL )
+		m_pFile( NULL ),
+        m_bEnableOutputBuffering( bEnableOutputBuffering )
 	{
 		m_bNullTerminatesStrings = false;
 
@@ -165,6 +166,13 @@ namespace logog {
 				WriteUnicodeBOM();
 			}
 #endif
+		}
+
+		// Disable output buffering if requested.
+		// Buffering is performed by default.
+		if (!m_bEnableOutputBuffering)
+		{
+			setvbuf(m_pFile, NULL, _IONBF, 0);
 		}
 
 		return ( m_pFile ? 0 : -1 );


### PR DESCRIPTION
Hi,
I've modified LogFile with the following changes:
1. Allow log file to be read by other processes on Windows (currently external read access is denied).
2. Allow to disable LogFile output buffering, using a constructor parameter.

Please review the changes and merge them if acceptable.

Thanks,
Shahar
