### PR TITLE
Flush data after each write in LogFile target.

### DIFF
--- a/src/target.cpp
+++ b/src/target.cpp
@@ -197,12 +197,15 @@ namespace logog {
 	}
 
 	int LogFile::InternalOutput( size_t nSize, const LOGOG_CHAR *pData )
-		{
-        size_t result;
+	{
+		size_t result;
 
 		result = fwrite( pData, sizeof( LOGOG_CHAR ), nSize, m_pFile );
 
 		if ( (size_t)result != nSize )
+			return -1;
+
+		if ( fflush(m_pFile) != 0)
 			return -1;
 
 		return 0;


### PR DESCRIPTION
This will ensure that every log line is written to disk. In case of
unexpected application exit you can almost always see a valid log.

It makes "tail -f" look better too. This might make too much
overhead in logging intensive applications. Consider using syslog target,
or LogBuffer then.
