### PR TITLE
Changed return type of initializer functions.

### DIFF
--- a/include/api.hpp
+++ b/include/api.hpp
@@ -35,12 +35,12 @@ struct INIT_PARAMS
  * use default values.
  * \sa INIT_PARAMS
  */
-extern int Initialize( INIT_PARAMS *params = NULL );
+extern void Initialize( INIT_PARAMS *params = NULL );
 
 /** Shuts down the logog system and frees all memory allocated by logog.  Memory still allocated by the logog system after Shutdown() indicates
  ** a bug.
  **/
-extern int Shutdown( );
+extern void Shutdown( );
 
 }
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -11,7 +11,7 @@ namespace logog {
 static Mutex s_mInitialization;
 static int s_nInitializations = 0;
 
-int Initialize( INIT_PARAMS *params )
+void Initialize( INIT_PARAMS *params )
 {
 	s_mInitialization.MutexLock();
 
@@ -43,11 +43,9 @@ int Initialize( INIT_PARAMS *params )
 	}
 
 	s_mInitialization.MutexUnlock();
-
-    return 0;
 }
 
-int Shutdown( )
+void Shutdown( )
 {
 	s_mInitialization.MutexLock();
 
@@ -67,8 +65,6 @@ int Shutdown( )
 	}
 
 	s_mInitialization.MutexUnlock();
-
-    return 0;
 }
 }
 


### PR DESCRIPTION
This will allow easy shutdown using std::atexit which was impossible when the return value of Shutdown was int.

This does not affect existing code, and could help with a "safe" shutting down like this:

``` c++
int main()
{
  logog::Initialize();
  std::atexit(&logog::Shutdown);
  // …
}
```
