### PR TITLE
Fix Thread::m_Thread is uninitialized.

### DIFF
--- a/include/thread.hpp
+++ b/include/thread.hpp
@@ -79,6 +79,7 @@ public:
     {
         m_pFnThreadStart = fnThreadStart;
         m_pvThreadParams = pvParams;
+        m_Thread = NULL;
     }
 
     /** Cause the created thread to commence execution asynchronously. */


### PR DESCRIPTION
Hi John,

I hope all is well with you!

-This PR fixes the warning in the application using logog.
-Tests with logog\cmake\Debug\test-logog.exe were successful.

Cheers!