### PR TITLE
Fix error while converting to non-pointer type.

### DIFF
--- a/include/thread.hpp
+++ b/include/thread.hpp
@@ -79,7 +79,7 @@ public:
     {
         m_pFnThreadStart = fnThreadStart;
         m_pvThreadParams = pvParams;
-        m_Thread = NULL;
+        m_Thread = nullptr;
     }
 
     /** Cause the created thread to commence execution asynchronously. */


### PR DESCRIPTION
_Details of the issue:_

/home/travis/build/johnwbyrd/logog/include/thread.hpp:82:18: error: converting to non-pointer type `pthread_t {aka long unsigned int}` from NULL [-Werror=conversion-null]
         m_Thread = NULL;

_Tests:_

**Windows 10**
- Success running "test-logog.exe"

**macOS Catalina 10.15.7**
- Success running "mkdir build && mkdir build/Debug && mkdir build/Release && cd build/Debug && cmake -DCMAKE_BUILD_TYPE=Debug ../.. && make && ctest -VV -C Debug && cd ../Release && cmake -DCMAKE_BUILD_TYPE=Release ../.. && make && ctest -VV -C Release"